### PR TITLE
Fix notification icon not showing on Deepin

### DIFF
--- a/zapzap/services/dbus_notify.py
+++ b/zapzap/services/dbus_notify.py
@@ -165,7 +165,7 @@ class Notification(object):
 
     def setIconPath(self, icon_path):
         """Set the URI of the icon to display in the notification"""
-        self.hints['image-path'] = 'file://' + icon_path
+        self.hints['image-path'] = icon_path
 
     def setQIcon(self, q_icon):
         # FixMe this would be convenient, but may not be possible


### PR DESCRIPTION
Oi, Rafa!
Um tempo atrás discutimos sobre o ícone da notificação não ser exibido no Deepin em https://github.com/rafatosta/zapzap/issues/84
Consegui identificar a causa e esse commit resolve o problema. Favor testá-lo no seu ambiente. Caso ocorra alguma incompatibilidade, posso fazer a detecção do S.O. de forma que a linha seja aplicada somente no Deepin.